### PR TITLE
Fix TinyColor website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](http://img.shields.io/npm/v/rescript-tinycolor.svg)](https://www.npmjs.org/package/rescript-tinycolor)
 [![Build Status](https://travis-ci.com/mikaello/rescript-tinycolor.svg?branch=master)](https://travis-ci.com/mikaello/rescript-tinycolor)
 
-ReScript bindings for [TinyColor](https://github.com/scttcper/tinycolor): fast, small color manipulation and conversion. See also [https://tinycolor.netlify.app](https://tinycolor.netlify.app)
+ReScript bindings for [TinyColor](https://github.com/scttcper/tinycolor): fast, small color manipulation and conversion. See also <https://tinycolor.vercel.app>
 
 ## Getting started
 


### PR DESCRIPTION
Also, when you just have a single url you want to be converted to link, using `<link>` is enough in markdown :)