### PR TITLE
fix: add sideEffects false for tree-shaking support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jest": "27.5.1",
     "rescript": "12.2.0"
   },
+  "sideEffects": false,
   "dependencies": {
     "@ctrl/tinycolor": "4.2.0"
   }


### PR DESCRIPTION
Without this field, bundlers (webpack/rollup) cannot safely tree-shake unused exports from rescript-tinycolor. Setting sideEffects to false aligns with @ctrl/tinycolor which already declares this.