### PR TITLE
fix: resolve all build warnings

### DIFF
--- a/__tests__/Tinycolor_tests.res
+++ b/__tests__/Tinycolor_tests.res
@@ -2,8 +2,6 @@ open Jest
 open Expect
 open! Expect.Operators
 
-open Belt
-
 describe("making tinycolor", () => {
   test("fromString() returns valid from string", () => {
     let black = TinyColor.makeFromString("black")
@@ -435,11 +433,11 @@ describe("color modification tests", () => {
 
 describe("color combinations", () => {
   let mapAndReturnHexArray = (color, fn) =>
-    Option.map(color, fn)->Option.getWithDefault([])->Array.map(TinyColor.toHexString)
+    Option.map(color, fn)->Option.getOr([])->Belt.Array.map(TinyColor.toHexString)
 
   test("analogous()", () =>
     TinyColor.makeFromString("#f00")
-    ->Option.getExn
+    ->Option.getOrThrow
     ->TinyColor.analogous()
     ->Array.map(TinyColor.toHexString)
     ->expect
@@ -448,7 +446,7 @@ describe("color combinations", () => {
 
   test("monochromatic()", () =>
     TinyColor.makeFromString("#f00")
-    ->Option.getExn
+    ->Option.getOrThrow
     ->TinyColor.monochromatic()
     ->Array.map(TinyColor.toHexString)
     ->expect
@@ -475,7 +473,7 @@ describe("color combinations", () => {
 
   test("polyad()", () =>
     TinyColor.makeFromString("#f00")
-    ->Option.getExn
+    ->Option.getOrThrow
     ->TinyColor.polyad(~n=4, ())
     ->Array.map(TinyColor.toHexString)
     ->expect
@@ -496,14 +494,14 @@ describe("color utils", () => {
     let a = TinyColor.makeFromString("red")
     let b = TinyColor.makeFromRgb({r: 255, g: 0, b: 0})
 
-    expect(Option.eq(a, b, TinyColor.equals)) === true
+    expect(Option.equal(a, b, TinyColor.equals)) === true
   })
 
   test("equals() returns false for unequal colors", () => {
     let a = TinyColor.makeFromString("red")
     let b = TinyColor.makeFromString("blue")
 
-    expect(Option.eq(a, b, TinyColor.equals)) === false
+    expect(Option.equal(a, b, TinyColor.equals)) === false
   })
 
   test("random()", () => {
@@ -521,31 +519,31 @@ describe("color utils", () => {
 
   test("randomMultiple() returns empty array for count=0", () => {
     let a = TinyColor.randomMultiple(~count=0, ())
-    expect(Array.length(a))->toBe(0)
+    expect(Belt.Array.length(a))->toBe(0)
   })
 
   test("randomMultiple() returns single element in array", () => {
     let a = TinyColor.randomMultiple(~count=1, ())
 
-    expect(Array.length(a))->toBe(1)
+    expect(Belt.Array.length(a))->toBe(1)
   })
 
   test("randomMultiple() returns many elements", () => {
     let a = TinyColor.randomMultiple(~count=15, ())
 
-    expect(Array.length(a))->toBe(15)
+    expect(Belt.Array.length(a))->toBe(15)
   })
 
   test("randomMultiple() returns all different colors", () => {
     let a = TinyColor.randomMultiple(~count=4, ())
 
     expect(
-      !TinyColor.equals(Array.getExn(a, 0), Array.getExn(a, 1)) &&
-      (!TinyColor.equals(Array.getExn(a, 0), Array.getExn(a, 2)) &&
-      (!TinyColor.equals(Array.getExn(a, 0), Array.getExn(a, 3)) &&
-      (!TinyColor.equals(Array.getExn(a, 1), Array.getExn(a, 2)) &&
-      (!TinyColor.equals(Array.getExn(a, 1), Array.getExn(a, 3)) &&
-      !TinyColor.equals(Array.getExn(a, 2), Array.getExn(a, 3)))))),
+      !TinyColor.equals(Belt.Array.getExn(a, 0), Belt.Array.getExn(a, 1)) &&
+      (!TinyColor.equals(Belt.Array.getExn(a, 0), Belt.Array.getExn(a, 2)) &&
+      (!TinyColor.equals(Belt.Array.getExn(a, 0), Belt.Array.getExn(a, 3)) &&
+      (!TinyColor.equals(Belt.Array.getExn(a, 1), Belt.Array.getExn(a, 2)) &&
+      (!TinyColor.equals(Belt.Array.getExn(a, 1), Belt.Array.getExn(a, 3)) &&
+      !TinyColor.equals(Belt.Array.getExn(a, 2), Belt.Array.getExn(a, 3)))))),
     ) === true
   })
 

--- a/src/TinyColor.res
+++ b/src/TinyColor.res
@@ -1,4 +1,3 @@
-open Belt
 type t
 
 @deriving(jsConverter)
@@ -322,24 +321,13 @@ external monochromatic: (t, ~results: int=?, unit) => array<t> = "monochromatic"
 @module("@ctrl/tinycolor")
 external randomMultiple: 'config => array<t> = "random"
 
-@obj
-external randomConfig: (
-  ~hue: [
-    | #red
-    | #orange
-    | #yellow
-    | #green
-    | #blue
-    | #purple
-    | #pink
-    | #monochrome
-  ]=?,
-  ~luminosity: [#bright | #light | #dark]=?,
-  ~seed: int=?,
-  ~alpha: float=?,
-  ~count: int=?,
-  unit,
-) => _ = ""
+type randomConfigType = {
+  hue?: [#red | #orange | #yellow | #green | #blue | #purple | #pink | #monochrome],
+  luminosity?: [#bright | #light | #dark],
+  seed?: int,
+  alpha?: float,
+  count?: int,
+}
 
 let random = (
   ~hue: option<
@@ -358,7 +346,7 @@ let random = (
   ~seed: option<int>=?,
   ~alpha: option<float>=?,
   (),
-) => random(randomConfig(~hue?, ~luminosity?, ~seed?, ~alpha?, ()))
+) => random({?hue, ?luminosity, ?seed, ?alpha})
 
 let randomMultiple = (
   ~hue: option<
@@ -378,13 +366,15 @@ let randomMultiple = (
   ~alpha: option<float>=?,
   ~count: int,
   (),
-) => randomMultiple(randomConfig(~hue?, ~luminosity?, ~seed?, ~alpha?, ~count, ()))
+) => randomMultiple({?hue, ?luminosity, ?seed, ?alpha, count})
 
 @module("@ctrl/tinycolor")
 external readability: (t, t) => float = "readability"
 
-@obj
-external wcagOption: (~level: [#AA | #AAA]=?, ~size: [#small | #large]=?) => _ = ""
+type wcagOptionType = {
+  level?: [#AA | #AAA],
+  size?: [#small | #large],
+}
 
 @module("@ctrl/tinycolor")
 external isReadable: (t, t, 'wcagObject) => bool = "isReadable"
@@ -393,14 +383,13 @@ let isReadable = (
   ~size: option<[#small | #large]>=?,
   color1: t,
   color2: t,
-) => isReadable(color1, color2, wcagOption(~level?, ~size?))
+) => isReadable(color1, color2, {?level, ?size})
 
-@obj
-external mostReadableConfig: (
-  ~includeFallbackColors: bool=?,
-  ~level: [#AA | #AAA]=?,
-  ~size: [#small | #large]=?,
-) => _ = ""
+type mostReadableConfigType = {
+  includeFallbackColors?: bool,
+  level?: [#AA | #AAA],
+  size?: [#small | #large],
+}
 
 @module("@ctrl/tinycolor")
 external mostReadable: (t, array<t>, 'config) => t = "mostReadable"
@@ -410,5 +399,4 @@ let mostReadable = (
   ~size: option<[#small | #large]>=?,
   compareColors: array<t>,
   color: t,
-) =>
-  mostReadable(color, compareColors, mostReadableConfig(~includeFallbackColors?, ~level?, ~size?))
+) => mostReadable(color, compareColors, {?includeFallbackColors, ?level, ?size})


### PR DESCRIPTION
- Remove open Belt in TinyColor.res; Option.map and Option.flatMap are available in the stdlib with the same interface
- Replace deprecated @obj externals (randomConfig, wcagOption, mostReadableConfig) with record types using optional fields
- Remove open Belt in Tinycolor_tests.res; qualify Belt.Array calls explicitly since stdlib Array lacks map/length/getExn
- Replace deprecated Option.getWithDefault with getOr, Option.getExn with getOrThrow, and Option.eq with Option.equal