### PR TITLE
ci: fix check of formatting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,6 @@ jobs:
         cache: 'yarn'
     - run: yarn install --frozen-lockfile
     - name: Check formatting
-      run: yarn rescript format --check
+      run: yarn check
     - name: Run the tests 👀
       run: yarn test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,6 @@ jobs:
         cache: 'yarn'
     - run: yarn install --frozen-lockfile
     - name: Check formatting
-      run: yarn rescript format -check
+      run: yarn rescript format --check
     - name: Run the tests 👀
       run: yarn test

--- a/__tests__/Tinycolor_tests.res
+++ b/__tests__/Tinycolor_tests.res
@@ -75,9 +75,7 @@ describe("making tinycolor", () => {
     let input: TinyColor.rgbaRatio = {r: 0.1, g: 0.5, b: 0.7, a: 0.7}
     let a = TinyColor.makeFromRgbaRatio(input)
 
-    expect(Option.map(a, TinyColor.getOriginalInput))->toEqual(
-      Some(TinyColor.rgbaRatioToJs(input)),
-    )
+    expect(Option.map(a, TinyColor.getOriginalInput))->toEqual(Some(TinyColor.rgbaRatioToJs(input)))
   })
 
   test("makeFromHsl() returns valid", () => {
@@ -112,9 +110,7 @@ describe("making tinycolor", () => {
     let input: TinyColor.hslaRatio = {h: 0.1, s: 0.5, l: 0.7, a: 0.7}
     let a = TinyColor.makeFromHslaRatio(input)
 
-    expect(Option.map(a, TinyColor.getOriginalInput))->toEqual(
-      Some(TinyColor.hslaRatioToJs(input)),
-    )
+    expect(Option.map(a, TinyColor.getOriginalInput))->toEqual(Some(TinyColor.hslaRatioToJs(input)))
   })
 
   test("makeFromHsv() returns valid", () => {
@@ -149,9 +145,7 @@ describe("making tinycolor", () => {
     let input: TinyColor.hsvaRatio = {h: 0.1, s: 0.5, v: 0.7, a: 0.7}
     let a = TinyColor.makeFromHsvaRatio(input)
 
-    expect(Option.map(a, TinyColor.getOriginalInput))->toEqual(
-      Some(TinyColor.hsvaRatioToJs(input)),
-    )
+    expect(Option.map(a, TinyColor.getOriginalInput))->toEqual(Some(TinyColor.hsvaRatioToJs(input)))
   })
   test("makeFromCmyk() returns valid", () => {
     let a = TinyColor.makeFromCmyk({c: 0, m: 100, y: 100, k: 0})
@@ -217,9 +211,7 @@ describe("onBackground()", () => {
     switch (blue, red) {
     | (Some(blue), Some(red)) =>
       let bluePartlyTransparent = TinyColor.setAlpha(0.5, blue)
-      expect(
-        TinyColor.onBackground(bluePartlyTransparent, red)->TinyColor.toHexString,
-      ) == "#800080"
+      expect(TinyColor.onBackground(bluePartlyTransparent, red)->TinyColor.toHexString) == "#800080"
     | _ => expect(true) == false
     }
   )
@@ -354,68 +346,70 @@ describe("color modification tests", () => {
 
   test("lighten(int, t)", () =>
     optionMapTwo(red, c => TinyColor.lighten(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#ff3333"))
+    ->expect
+    ->toEqual(Some("#ff3333"))
   )
 
   test("lighten(int, t) does not change original instance", () =>
     optionMapTwo(red, c => TinyColor.lighten(~value=10, c), TinyColor.toHex8String)
-   ->expect
-   ->not_
-   ->toEqual(Option.map(red, TinyColor.toHex8String))
+    ->expect
+    ->not_
+    ->toEqual(Option.map(red, TinyColor.toHex8String))
   )
 
   test("brighten(int, t)", () =>
     optionMapTwo(red, c => TinyColor.brighten(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#ff1919"))
+    ->expect
+    ->toEqual(Some("#ff1919"))
   )
 
   test("brighten(int, t) dose not change original instance", () =>
     optionMapTwo(red, c => TinyColor.brighten(~value=10, c), TinyColor.toString)
-   ->expect
-   ->not_
-   ->toEqual(Option.map(red, TinyColor.toString))
+    ->expect
+    ->not_
+    ->toEqual(Option.map(red, TinyColor.toString))
   )
 
   test("darken(int, t)", () =>
     optionMapTwo(red, c => TinyColor.darken(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#cc0000"))
+    ->expect
+    ->toEqual(Some("#cc0000"))
   )
 
   test("tint(int, t)", () =>
     optionMapTwo(red, c => TinyColor.tint(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#ff1a1a"))
+    ->expect
+    ->toEqual(Some("#ff1a1a"))
   )
 
   test("shade(int, t)", () =>
     optionMapTwo(red, c => TinyColor.shade(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#e60000"))
+    ->expect
+    ->toEqual(Some("#e60000"))
   )
 
   test("desaturate(int, t)", () =>
     optionMapTwo(red, c => TinyColor.desaturate(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#f20d0d"))
+    ->expect
+    ->toEqual(Some("#f20d0d"))
   )
 
   test("saturate(int, t)", () =>
     optionMapTwo(red, c => TinyColor.saturate(~value=10, c), TinyColor.toHexString)
-   ->expect
-   ->toEqual(Some("#ff0000"))
+    ->expect
+    ->toEqual(Some("#ff0000"))
   )
 
   test("spin(int, t)", () =>
-    Option.map(red, c => TinyColor.spin(~value=180, c))->Option.map(TinyColor.toHex8String)
-   ->expect === Some("#00ffffff")
+    Option.map(red, c => TinyColor.spin(~value=180, c))
+    ->Option.map(TinyColor.toHex8String)
+    ->expect === Some("#00ffffff")
   )
 
   test("spin(int, t) with value 360 does not change", () =>
-    Option.map(red, c => TinyColor.spin(~value=360, c))->Option.map(TinyColor.toHex8String)
-   ->expect === Option.map(red, TinyColor.toHex8String)
+    Option.map(red, c => TinyColor.spin(~value=360, c))
+    ->Option.map(TinyColor.toHex8String)
+    ->expect === Option.map(red, TinyColor.toHex8String)
   )
 
   test("mix(int, t)", () => {
@@ -424,16 +418,18 @@ describe("color modification tests", () => {
 
     switch (color1, color2) {
     | (Some(c1), Some(c2)) =>
-      TinyColor.mix(~value=50, c1, c2)->Option.map(TinyColor.toHexString)
-     ->expect
-     ->toEqual(Some("#808080"))
+      TinyColor.mix(~value=50, c1, c2)
+      ->Option.map(TinyColor.toHexString)
+      ->expect
+      ->toEqual(Some("#808080"))
     | _ => expect(false) === true
     }
   })
 
   test("greyscale(t)", () =>
-    Option.map(red, TinyColor.greyscale)->Option.map(TinyColor.toHex8String)
-   ->expect === Some("#808080ff")
+    Option.map(red, TinyColor.greyscale)
+    ->Option.map(TinyColor.toHex8String)
+    ->expect === Some("#808080ff")
   )
 })
 
@@ -446,8 +442,8 @@ describe("color combinations", () => {
     ->Option.getExn
     ->TinyColor.analogous()
     ->Array.map(TinyColor.toHexString)
-   ->expect
-   ->toEqual(["#ff0000", "#ff0066", "#ff0033", "#ff0000", "#ff3300", "#ff6600"])
+    ->expect
+    ->toEqual(["#ff0000", "#ff0066", "#ff0033", "#ff0000", "#ff3300", "#ff6600"])
   )
 
   test("monochromatic()", () =>
@@ -455,26 +451,26 @@ describe("color combinations", () => {
     ->Option.getExn
     ->TinyColor.monochromatic()
     ->Array.map(TinyColor.toHexString)
-   ->expect
-   ->toEqual(["#ff0000", "#2a0000", "#550000", "#800000", "#aa0000", "#d40000"])
+    ->expect
+    ->toEqual(["#ff0000", "#2a0000", "#550000", "#800000", "#aa0000", "#d40000"])
   )
 
   test("splitcomplement()", () =>
     mapAndReturnHexArray(TinyColor.makeFromString("#f00"), TinyColor.splitcomplement)
-   ->expect
-   ->toEqual(["#ff0000", "#ccff00", "#0066ff"])
+    ->expect
+    ->toEqual(["#ff0000", "#ccff00", "#0066ff"])
   )
 
   test("triad()", () =>
     mapAndReturnHexArray(TinyColor.makeFromString("#f00"), TinyColor.triad)
-   ->expect
-   ->toEqual(["#ff0000", "#00ff00", "#0000ff"])
+    ->expect
+    ->toEqual(["#ff0000", "#00ff00", "#0000ff"])
   )
 
   test("tetrad()", () =>
     mapAndReturnHexArray(TinyColor.makeFromString("#f00"), TinyColor.tetrad)
-   ->expect
-   ->toEqual(["#ff0000", "#80ff00", "#00ffff", "#7f00ff"])
+    ->expect
+    ->toEqual(["#ff0000", "#80ff00", "#00ffff", "#7f00ff"])
   )
 
   test("polyad()", () =>
@@ -482,8 +478,8 @@ describe("color combinations", () => {
     ->Option.getExn
     ->TinyColor.polyad(~n=4, ())
     ->Array.map(TinyColor.toHexString)
-   ->expect
-   ->toEqual(["#ff0000", "#80ff00", "#00ffff", "#7f00ff"])
+    ->expect
+    ->toEqual(["#ff0000", "#80ff00", "#00ffff", "#7f00ff"])
   )
 
   test("complement()", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rescript-tinycolor",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rescript-tinycolor",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "4.2.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "build": "rescript build",
     "start": "rescript build -w",
     "clean": "rescript clean",
+    "check": "rescript format --check",
+    "format": "rescript format",
     "pretest": "npm run build",
     "test": "jest"
   },


### PR DESCRIPTION
Ref the current output:

```
Run yarn rescript format -check
yarn run v1.22.22
$ /home/runner/work/rescript-tinycolor/rescript-tinycolor/node_modules/.bin/rescript format -check
Format ReScript files

Usage: rescript format [OPTIONS] [FILES]...

Arguments:
  [FILES]...  Files to format. If no files are provided, all files are formatted

Options:
  -c, --check          Check formatting status without applying changes
  -v, --verbose...     Increase logging verbosity
  -q, --quiet...       Decrease logging verbosity
  -s, --stdin <STDIN>  Read the code from stdin and print the formatted code to stdout [possible values: .res, .resi]
  -h, --help           Print help
Done in 0.09s.
```